### PR TITLE
[MP] [2p - Dark Forecast] Make Dark Forecast at least winnable in 2 player mode.

### DIFF
--- a/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
+++ b/data/multiplayer/scenarios/2p_Dark_Forecast.cfg
@@ -117,6 +117,12 @@ Note: You need to use the default map settings for the scenario to work right."
             [else]
                 {VARIABLE lose_condition_string ( _ "Death of both of your team’s leaders")}
                 {VARIABLE notes ( _ "Since your team has two leaders, the enemy waves will be at full strength.")}
+                # each village will now support an upkeep of 2 instead of 1
+                # this makes the scenario somewhat passable now.
+                [modify_side]
+                    side=3,4
+                    village_support=2
+                [/modify_side]
             [/else]
         [/if]
         {CLEAR_VARIABLE leader}


### PR DESCRIPTION
This PR makes Dark Forecast "passable" at default difficulty for 2 player mode. Initially, it was only passable if it was one-player-mode as one player could have 11 villages active and could get a good army built prior to the final wave.
2 player mode suffers from lack of resources to replace losses and would be unwinnable in some cases.

The change which has been made is that in 2-player-mode, the `village_support` has been set to 2. 

The only 2 cases where it was won in 2 player mode was when the players were of exceptionally high skill level but average skill-levelled players have yet to even win.

This PR fixes #5651